### PR TITLE
Fix snack and armor menu macros

### DIFF
--- a/GTA V Online Macros.ahk
+++ b/GTA V Online Macros.ahk
@@ -266,7 +266,7 @@ openSnackMenu() {
 }
 
 openArmorMenu() {
-  Send {Down}{Down}{Enter}{Down}{Enter}
+  Send {Down}{Down}{Enter}{Down}{Down}{Down}{Enter}
 }
 
 openOutfitMenu() {

--- a/GTA V Online Macros.ahk
+++ b/GTA V Online Macros.ahk
@@ -262,7 +262,7 @@ openInteractionMenu(isVIPActive, isCPHActive) {
 }
 
 openSnackMenu() {
-  Send {Down}{Down}{Enter}{Down}{Down}{Enter}
+  Send {Down}{Down}{Enter}{Down}{Down}{Down}{Down}{Enter}
 }
 
 openArmorMenu() {


### PR DESCRIPTION
The addition of the "Media Player" and "Radio Station Favorites" to the Inventory menu messed up the macros for opening the  snack and armor menus. All that was necessary was adding a couple extra down keys to the functions for each of them. It doesn't seem like any other functionality was affected by the update, as far as I could tell. Seems to be the problem mentioned in #8 